### PR TITLE
add entry points for plottr

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,14 @@ source:
   sha256: 7800f0ba704bfbfa0564538c790a3551142bb5e23cbe7282e69d4f9ffe0d9536
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py27]
   skip: true  # [py36]
   script: "{{ PYTHON }} -m pip install . -vv"
+  entry_points:
+    - plottr-monitr = plottr.apps.monitr:script
+    - plottr-inspectr = plottr.apps.inspectr:script
+    - plottr-autoplot-ddh5 = plottr.apps.autoplot:script
 
 requirements:
   build:


### PR DESCRIPTION
Currently trying to launch plottr results in 

```
Fatal error in launcher: Unable to create process using '"d:\bld\plottr_1615644268581\_h_env\python.exe"  "C:\Users\Jens-work\miniconda3\envs\condaforgeqcodes\Scripts\plottr-inspectr.exe" ': The system cannot find the file specified.
```
I.e. it is trying to use the path to where python was installed on the ci machine. Hopefully this will fix it

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
